### PR TITLE
Tidy build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Compiler stff
-CPP=clang++
-CPPFLAGS=-g -Wall -Werror -D CBF
+CPP?=clang++
+CPPFLAGS?=-g -Wall -Werror -D CBF
 
 # Source File stuff
 INCDIR=include

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Simply hop into the directory and run make:
 
 ``` make ```
 
+The Makefile will use clang++ by default, but you can override the default with another compiler of your choice:
+
+``` CPP=g++ make ```
+
 ## Usage
 
 The ECE comes with a ready made set of cache admission (probabilistic,
@@ -61,7 +65,7 @@ made example script will perform an example using Second-Hit Caching and LRU:
 ``` ./run_em.sh <log directory> 2hc_lru ```
 
 Where `<log directory>` is a directory containing logs of the appropriate
-format.
+format.  Sample logs are provided in the directory `input_request_sequence`.
 
 Output will be placed in `out/<timestamp>`.
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# A convenience script to build and run
+# the simulator in one step.
+
+CPP=g++ make -j $(nproc) && ./run_em.sh input_request_sequence ./bin/lru_2hc

--- a/run_em.sh
+++ b/run_em.sh
@@ -3,48 +3,56 @@
 # Licensed under the terms of the Apache 2.0 open source license
 # See LICENSE file for terms.
 
-if [[ $# -eq 0 ]] ; then
+
+function run_test()
+{
+    local executable=$1
+    BINNAME=$(basename ${executable})
+    local LOGDIR=$2
+    
+    # Get the list of timestamps from the log file names in log directory 'LOGDIR'
+    LIST_OF_TS=`ls $LOGDIR/*.gz | awk -F "/" '{print $NF}' | awk -F'_' '{print $2}' | awk -F'.' '{print $1}' | sort -n | uniq`
+    
+    echo "Adding run of $executable to $RUNDIR/$BINNAME.dat"
+    
+    for i in $LIST_OF_TS; do
+        zcat $LOGDIR/*$i*.gz | sort -n
+    done | $executable > $RUNDIR/$BINNAME.dat
+    
+    echo "Finished $executable"
+}
+
+
+
+if [[ $# -lt 2 ]] ; then
     echo -e 'Usage:\n\trun_sim.sh <log dir> <exp_bin...>'
+    echo -e "\nTo use the provided sample logs and default Least Recently Used, Second Hit Caching simulator, \n use 'input_request_sequence' as the log_dir and '$(dirname $0)/bin/lru_2hc' as the experiment binary."
     exit 0
+fi
+
+if [ ! -f "$(dirname $0)/bin/lru_2hc" ]; then
+    echo -e 'ERROR: lru_2hc not found.\nPlease run "make" to build the binary before running this script.'
+    exit 1
 fi
 
 DATE=`date +%d_%b_%y-%H_%M`
 OUTDIR="out"
 LOGDIR=$1
 RUNDIR=$OUTDIR/$DATE
-BINNAME=${2##*/}
-
 echo "Output will be saved in: $RUNDIR"
+mkdir -p out;
+mkdir -p $RUNDIR;
 
-# Make the outdir
-if [ ! -d out ]; then
-  mkdir out;
-fi
+shift
 
-# Make the rundir
-if [ ! -d $RUNDIR ]; then
-  mkdir $RUNDIR;
-fi
-
-# Get the list of timestamps from the log file names in log directory 'LOGDIR'
-LIST_OF_TS=`ls $LOGDIR/*.gz | awk -F "/" '{print $NF}' | awk -F'_' '{print $2}' | awk -F'.' '{print $1}' | sort -n | uniq`
-
-# loop over the time stamps from the filenames, and
-# cat all files from that timestamp into tee (to pass to multiple instance of caching emulator binaries)
-COMMAND="for i in $LIST_OF_TS; do zcat $LOGDIR/*\$i*.gz | sort -n; done | tee "
-
-echo "Adding $2"
-
-NEW_CMD=">(/usr/bin/time --quiet -f "%e" $2 > $RUNDIR/$BINNAME.dat) "
-
-# final command
-COMMAND=$COMMAND$NEW_CMD
-
-COMMAND="$COMMAND > /dev/null"
-eval $COMMAND
+for executable in "$@"
+do
+    run_test $executable $LOGDIR
+done
 
 echo "Output was saved in: $RUNDIR"
 
 # Convenience, set a symlink so I can easily find these results
 rm $OUTDIR/latest
 ln -s $DATE $OUTDIR/latest
+


### PR DESCRIPTION
Fix run script to allow multiple binaries in a single invocation to match the documentation
Clean up run script, make '--help' print usage information
Add build.sh matching internal convention